### PR TITLE
Remove config files from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.9-alpine
 
 WORKDIR /usr/src/app
 
-COPY LICENSE gcp_ddns.py requirements.txt config.yaml ddns-api-key.json ./
+COPY LICENSE gcp_ddns.py requirements.txt ./
 
 RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT [ "python", "./gcp_ddns.py" ]
-CMD [ "config.yaml" ]
+CMD [ "/ddns/config.yaml" ]


### PR DESCRIPTION
1. Removed `config.yaml` and `ddns-api-key.json` from the Docker image - as they're config files they don't need to be in every image
2. Moved `config.yaml` back to `/ddns/` directory - I'm not sure why you changed this line, but having all 'google-ddns' files in one directory makes sense to me, so I reverted it - but maybe I've missed something :)

(hopefully) fixes #10 