### PR TITLE
Create Github Action to publish Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+.github/

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,43 @@
+# Based on https://docs.github.com/en/actions/guides/publishing-docker-images
+
+name: Create & publish google-ddns Docker image to ghcr.io
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,8 +1,11 @@
 # Based on https://docs.github.com/en/actions/guides/publishing-docker-images
+# Deploys to https://github.com/features/packages 
+# Can be triggered manually, or by creating a Release
 
 name: Create & publish google-ddns Docker image to ghcr.io
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
Following this guide: https://docs.github.com/en/actions/guides/publishing-docker-images

Example: 

https://github.com/aSemy/google-ddns/releases/tag/v0.0.1

https://github.com/aSemy/google-ddns/pkgs/container/google-ddns

How to create a release:

1. Create a tag e.g. `git tag v0.0.1`
2. Push the tag e.g. `git push origin v0.0.1`
3. Create a release https://github.com/conorcunningham/google-ddns/releases/new
4. The Github Action will build and release a new Docker image